### PR TITLE
Add nullable flag for edge-to-edge

### DIFF
--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1,4 +1,5 @@
 export type ConfigProps = {
   karteInfoPlist: string;
   karteXml: string;
+  isEdgeToEdgeEnabled?: boolean | null;
 };


### PR DESCRIPTION
## Summary
- add optional `isEdgeToEdgeEnabled` flag to `ConfigProps`
- remove inline comment for the new flag

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_683c3204c0a8832a85aa209c46da44e4